### PR TITLE
Fix title sent instead of cookie domain

### DIFF
--- a/PicoGAnalytics.php
+++ b/PicoGAnalytics.php
@@ -136,7 +136,7 @@ class PicoGAnalytics extends AbstractPicoPlugin
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-            ga('create', '" . $this->googleTrackingId . "', '" . $this->siteTitle . "');";
+            ga('create', '" . $this->googleTrackingId . "', 'auto');";
             // OPTION: DISPLAY FEATURES
             if ($this->displayFeatures === true) {
             $script .= "


### PR DESCRIPTION
See "Naming trackers" on https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers